### PR TITLE
Change default branch in readme, double dash in update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Utilities to aid in testing SimpleSAMLphp modules
 
 Install as a dev dependency using composer
 
-    composer require --dev  cirrusidentity/simplesamlphp-test-utils:dev-master
+    composer require --dev  cirrusidentity/simplesamlphp-test-utils:v2.x-dev
     
 Update the dependency
 
-    composer update -dev  cirrusidentity/simplesamlphp-test-utils
+    composer update --dev  cirrusidentity/simplesamlphp-test-utils
     
 # Usage
 


### PR DESCRIPTION
A few little things to help folks get v2 up and running. 

I noticed these when using `simplesamlphp-test-utils` to test an update I have for `simplesamlphp-module-sqlauth`. :)

I plan to update the https://github.com/simplesamlphp/simplesamlphp/blob/master/TESTING.md to link to the main SSP-test-utils repo at v2 to help folks getting up to speed with things for their module testing.